### PR TITLE
팀 후보 등록 API 구현 #11

### DIFF
--- a/src/utils/joi/teams.validation.js
+++ b/src/utils/joi/teams.validation.js
@@ -8,10 +8,15 @@ const teamIdBody = joi.object({
   enemyTeamId: joi.number().positive().integer().required(),
 });
 
-// 이거 얘기해보자
+// 팀 선수 선발 등록 body
 const teamInfoBody = joi.object({
   userPlayerId: joi.number().positive().integer().required(),
-  position: joi.number().min(1).max(3).integer(),
+  position: joi.number().min(1).max(3).integer().required(),
+});
+
+// 팀 선수 후보 등록 body
+const positionBody = joi.object({
+  position: joi.number().min(1).max(3).integer().required(),
 });
 
 export async function teamIdParamValidate(params) {
@@ -24,4 +29,8 @@ export async function teamIdBodyValidate(body) {
 
 export async function teamInfoBodyValidate(body) {
   return await teamInfoBody.validateAsync(body);
+}
+
+export async function positionBodyValidate(body) {
+  return await positionBody.validateAsync(body);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #11 

## 📝작업 내용

- 후보 등록 API를 구현 하였습니다.
- position을 body에 요청받아 해당 팀에 position위치에 있는 선수를 후보 등록하게(null로 변경) 만들었습니다.
- 추가로 position에 대한 유효성 검사 변수 함수도 추가하여 작성했습니다.

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
