### PR TITLE
[FEAT] 자동매치메이킹 API 구현 완료 - #23

### DIFF
--- a/src/routes/events.router.js
+++ b/src/routes/events.router.js
@@ -14,7 +14,10 @@ import {
 } from "../utils/logic/game.js";
 import { createMatchLogToDB } from "../utils/prisma/mathLogs.prisma.js";
 import { findPlayerFromDB } from "../utils/prisma/players.prisma.js";
-import { findTeamFromDB } from "../utils/prisma/teams.prisma.js";
+import {
+  findTeamFromDB,
+  findTeamsAutoMatchMakingFromDB,
+} from "../utils/prisma/teams.prisma.js";
 import {
   findUserFromDB,
   updateUserRatingToDB,
@@ -170,10 +173,15 @@ router.patch("/events/autoMatching/:teamId", async (req, res, next) => {
   try {
     const userId = 1; // req.header.authorization
     const { teamId: myTeamId } = await teamIdParamValidate(req.params);
-    const { enemyTeamId } = await teamIdBodyValidate(req.body);
+
+    const user = await findUserFromDB(userId);
+    const enemyTeams = await findTeamsAutoMatchMakingFromDB(
+      userId,
+      user.rating,
+    );
 
     const myTeam = await findTeamFromDB(myTeamId);
-    //const enemyTeam = await findTeamFromDB(enemyTeamId);
+    const enemyTeam = enemyTeams[Math.floor(Math.random() * enemyTeams.length)];
 
     // 내팀이 DB에 없는 경우
     if (!myTeam)
@@ -188,6 +196,98 @@ router.patch("/events/autoMatching/:teamId", async (req, res, next) => {
       throw new BadRequestError(
         "내 팀의 인원 수가 3명 미만이기 때문에 게임을 진행하실 수 없습니다.",
       );
+
+    const myTeamArr = [];
+    const enemyTeamArr = [];
+
+    for (let i = 1; i < 4; i++) {
+      const myPlayerId = myTeam[`UserPlayer` + i].playerId;
+      const myPlayer = await findPlayerFromDB(myPlayerId);
+      const myPlayerUpgrade = myTeam[`UserPlayer` + i].upgrade;
+
+      // 본인 플레이어 정보가 존재하지 않을 경우
+      if (!myPlayer)
+        throw new NotFoundError(
+          `내 팀 선수 중 (${myPlayerId}) 의 선수 데이터가 존재하지 않습니다.`,
+        );
+
+      myTeamArr.push({ player: myPlayer, upgrade: myPlayerUpgrade });
+
+      const enemyPlayerId = enemyTeam[`playerId` + i];
+      const enemyPlayer = await findPlayerFromDB(enemyPlayerId);
+      const enemyPlayerUpgrade = enemyTeam[`upgrade` + i];
+
+      // 상대 플레이어 정보가 존재하지 않을 경우
+      if (!myPlayer)
+        throw new NotFoundError(
+          `상대 팀 선수 중 (${enemyPlayerId}) 의 선수 데이터가 존재하지 않습니다.`,
+        );
+
+      enemyTeamArr.push({ player: enemyPlayer, upgrade: enemyPlayerUpgrade });
+    }
+
+    const myTeamScore = getTeamScore(myTeamArr);
+    const enemyTeamScore = getTeamScore(enemyTeamArr);
+
+    const matchResult = getMatchResult(myTeamScore, enemyTeamScore);
+
+    // 경기 결과에 대해 Rating 점수를 자신과 상대팀의 유저에게 반영한다.
+    // Rating 점수는 기본 10점이다.
+    // 불리한 조건(내 팀의 총 점수가 상대팀의 총 점수보다 낮을 때)
+    //    - 승리할 경우 : 기본 10점보다 더 준다.
+    //    - 패배할 경우 :
+    // 반면에, 유리한 조건일 경우 => 10점보다 덜 준다.
+    let changeRatingScore = getBonusRatingScore(
+      myTeamScore,
+      enemyTeamScore,
+      matchResult.result,
+    );
+
+    let myUser = null;
+    let enemyUser = null;
+    let message = "";
+
+    switch (matchResult.result) {
+      case MATCH_RESULT.WIN:
+        {
+          myUser = await updateUserRatingToDB(myTeam.userId, changeRatingScore);
+          enemyUser = await updateUserRatingToDB(
+            enemyTeam.userId,
+            -changeRatingScore,
+          );
+          message = `[${matchResult.score}] 로 승리하셨습니다!!! Rating이 ${changeRatingScore} 증가했습니다.`;
+        }
+        break;
+      case MATCH_RESULT.DRAW:
+        {
+          myUser = await findUserFromDB(myTeam.userId);
+          message = `[${matchResult.score}] 로 비겼습니다!!!`;
+        }
+        break;
+      case MATCH_RESULT.LOSE:
+        {
+          myUser = await updateUserRatingToDB(
+            myTeam.userId,
+            -changeRatingScore,
+          );
+          enemyUser = await updateUserRatingToDB(
+            enemyTeam.userId,
+            changeRatingScore,
+          );
+          message = `[${matchResult.score}] 로 패배하셨습니다... Rating이 ${changeRatingScore} 감소했습니다.`;
+        }
+        break;
+    }
+
+    // 경기 결과를 매치로그에 저장한다.
+    // - 우선 내 팀 기준의 MatchLog 만 저장하도록 한다.
+    const matchLog = await createMatchLogToDB(
+      myTeam.userId,
+      enemyTeam.userId,
+      matchResult.result,
+    );
+
+    return res.status(200).json({ message, rating: myUser.rating });
   } catch (error) {
     next(error);
   }

--- a/src/routes/gacha.router.js
+++ b/src/routes/gacha.router.js
@@ -19,7 +19,7 @@ const router = express.Router();
 router.post("/gacha", async (req, res, next) => {
   try {
     // userId는 인증처리 미들웨어 구현 후 추후 req.header.authorization 교체
-    const userId = 1;
+    const userId = 2;
     const { gachaCount } = await gachaBodyValidate(req.body);
 
     // user가 gacha를 gachaCount 할만큼 Cache가 있는지 체크

--- a/src/routes/teams.router.js
+++ b/src/routes/teams.router.js
@@ -1,13 +1,13 @@
 import express from "express";
-import { userPrisma, gamePrisma } from "../utils/prisma/index.js";
+import { BadRequestError } from "../errors/BadRequestError.js";
 import { ConflictError } from "../errors/ConflictError.js";
 import { NotFoundError } from "../errors/NotFoundError.js";
-import { BadRequestError } from "../errors/BadRequestError.js";
 import {
+  positionBodyValidate,
   teamIdParamValidate,
   teamInfoBodyValidate,
-  positionBodyValidate,
 } from "../utils/joi/teams.validation.js";
+import { gamePrisma, userPrisma } from "../utils/prisma/index.js";
 
 const router = express.Router();
 

--- a/src/routes/userPlayers.router.js
+++ b/src/routes/userPlayers.router.js
@@ -1,5 +1,4 @@
 import express from "express";
-import { prisma } from "../utils/prisma/index.js";
 
 const router = express.Router();
 

--- a/src/utils/logic/game.js
+++ b/src/utils/logic/game.js
@@ -40,20 +40,11 @@ export function getTeamScore(team) {
 export function getMatchResult(myTeamScore, enemyTeamScore) {
   // 최대 점수는 두 팀의 총 점수의 합으로 하시면 됩니다!
   const maxScore = myTeamScore + enemyTeamScore;
-  const randomValue = parseFloat(Math.random() * maxScore).toFixed(2);
+  const randomValue = Number((Math.random() * maxScore).toFixed(2));
 
   // 무승부 처리는 점수가 작은 팀의 총 점수의 10%를 범위로 하여 처리한다.
-  const drawRangeValue = parseFloat(
-    (Math.min(myTeamScore, enemyTeamScore) / 10).toFixed(2),
-  );
-
-  console.log(
-    myTeamScore,
-    enemyTeamScore,
-    myTeamScore - drawRangeValue,
-    myTeamScore + drawRangeValue,
-  );
-  console.log(randomValue, " => (", myTeamScore - drawRangeValue, ")");
+  const minScore = Math.min(myTeamScore, enemyTeamScore);
+  const drawRangeValue = Number((minScore / 10).toFixed(2));
 
   if (randomValue <= myTeamScore - drawRangeValue) {
     // A 유저 승리 처리

--- a/src/utils/prisma/teams.prisma.js
+++ b/src/utils/prisma/teams.prisma.js
@@ -14,3 +14,28 @@ export async function findTeamFromDB(teamId) {
 
   return team;
 }
+
+// 자동 매치 메이킹으로 유저의 Rating 점수와 비슷한 다른 유저의 팀 N개를 조회한다.
+export async function findTeamsAutoMatchMakingFromDB(userId, userRating) {
+  const autoMatchMakingTeams =
+    await userPrisma.$queryRaw`SELECT t.userId, ABS( u.rating - 977) AS gap,
+    t.teamId, 
+    t.userPlayerId1, 
+    up1.playerId AS playerId1,
+    up2.playerId AS playerId2,
+    up3.playerId AS playerId3,
+    up1.upgrade AS upgrade1,
+    up2.upgrade AS upgrade2,
+    up3.upgrade AS upgrade3,
+    t.userPlayerId2, 
+    t.userPlayerId3 FROM Users u
+    INNER JOIN Teams t ON t.userId=u.userId
+    INNER JOIN UserPlayers up1 ON t.userPlayerId1=up1.userPlayerId
+    INNER JOIN UserPlayers up2 ON t.userPlayerId2=up2.userPlayerId 
+    INNER JOIN UserPlayers up3 ON t.userPlayerId3=up3.userPlayerId 
+    GROUP BY t.userId HAVING t.userPlayerId1 IS NOT NULL AND t.userPlayerId2 IS NOT NULL AND t.userPlayerId3 IS NOT NULL AND t.userId != 1
+    ORDER BY gap ASC
+    LIMIT 10;`;
+
+  return autoMatchMakingTeams;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #23 

## 📝작업 내용

[FEAT] 자동매치메이킹 API 구현 완료

1) prisma의 raw query를 사용하여 복잡한 쿼리문을 작성해봤습니다.
    - 자신의 Rating과 가장 가까운 다른 유저들을 최대 10명 조회하는 쿼리문 작성

2) 비슷한 Rating의 다른 유저의 팀들 중 랜덤하게 한 팀을 선택하여 게임 플레이를 한다.

3) 게임 플레이 로직은 #8과 동일합니다. 참고바랍니다

## 💬리뷰 요구사항(선택)

- 테스트 해보시고 버그 발견 시 알려주시면 감사하겠습니다.
